### PR TITLE
Scope installation token to repository where the push happened 

### DIFF
--- a/src/handlers/push.ts
+++ b/src/handlers/push.ts
@@ -7,7 +7,10 @@ export const repository_dispatch_type = 'org-workflow-bot'
 async function handlePush(context: Context): Promise<void> {
   const sha = context.payload.after
   const webhook = await context.octokit.apps.getWebhookConfigForApp()
-  const token = await context.octokit.apps.createInstallationAccessToken({ installation_id: context?.payload?.installation?.id || 0 })
+  const token = await context.octokit.apps.createInstallationAccessToken({ 
+    installation_id: context?.payload?.installation?.id || 0,
+    repository_ids: [context.payload.repository.id] 
+  })
 
   const data = {
     sha,

--- a/test/handlers/push.test.ts
+++ b/test/handlers/push.test.ts
@@ -22,6 +22,7 @@ describe('push handler', () => {
         before: "bc5b6d4f4a5b2eb3d89f52d46d75f2129c63b074",
         after: "89c9e6dc89fce3971570dba9b07052973bff7e13",
         repository: {
+          id: 33241,
           name: 'rudolph',
           full_name: 'santa/rudolph',
           owner: {
@@ -47,6 +48,14 @@ describe('push handler', () => {
     } as any
 
     mockingoose(runsModel).toReturn({ _id: id }, 'save');
+  })
+
+  test('should createInstallationAccessToken that is scoped to push repository', async () => {
+    await handlePush(context);
+    expect(context.octokit.apps.createInstallationAccessToken).toBeCalledWith({
+      installation_id: event.payload.installation.id,
+      repository_ids: [event.payload.repository.id]
+    })
   })
 
   test('should call octokit createDispatchEvent correct data', async () => {


### PR DESCRIPTION
See: https://docs.github.com/en/free-pro-team@latest/rest/reference/apps#create-an-installation-access-token-for-an-app

By adding `repository_ids` to the `createInstallationAccessToken` it ensures that only the repository the used pushed to can be accessed. 

- [x] Added specs 

This PR fixes https://github.com/SvanBoxel/organization-workflows/issues/14