### PR TITLE
Add exclude config option

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -84,3 +84,5 @@ jobs:
           core.info(`Running e2e test for staging environment`);
           const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/e2e-test.js`);
           await script(${{ env.APP_ID_STAGING }}, "${{ env.TEST_ORG }}", {github, core});
+          await script(app_id, "${{ env.TEST_ORG }}", {github, core}, { repoName: 'exlude-me', shouldrun: false });
+          await script(app_id, "${{ env.TEST_ORG }}", {github, core}, { repoName: 'wildcard-test', shouldrun: false });

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -35,5 +35,6 @@ jobs:
             
             const app_id = envMap[env];
             const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/e2e-test.js`);
-            await script(app_id, "${{ env.TEST_ORG }}", {github, core});
             
+            await script(app_id, "${{ env.TEST_ORG }}", {github, core});
+            await script(app_id, "${{ env.TEST_ORG }}", {github, core}, { repoName: 'wildcard-test', shouldrun: false });

--- a/.github/workflows/promote-environment.yml
+++ b/.github/workflows/promote-environment.yml
@@ -53,3 +53,4 @@ jobs:
 
           const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/e2e-test.js`);
           await script(${{ env.APP_ID_PRODUCTION }}, "${{ env.TEST_ORG }}", {github, core});
+          await script(app_id, "${{ env.TEST_ORG }}", {github, core}, { repoName: 'wildcard-test', shouldrun: false });

--- a/.github/workflows/scripts/e2e-test.js
+++ b/.github/workflows/scripts/e2e-test.js
@@ -1,5 +1,5 @@
-module.exports = async (APP_ID, TEST_ORG, { github, core }) => {
-  const repoName = Math.random().toString(36).substring(7)
+module.exports = async (APP_ID, TEST_ORG, { github, core }, { repoName, shouldRun = true }) => {
+  const repoName = Math.random().toString(36).substring(7);
   const buffer = new Buffer('Test commit');
   const content = buffer.toString('base64');
 
@@ -43,8 +43,14 @@ module.exports = async (APP_ID, TEST_ORG, { github, core }) => {
     repo: repoName
   });
   
+  const foundCheckRun = checkResult.data.check_runs.some(check => check.app.id === APP_ID);
   // Check whether check is created by this app
-  if(!checkResult.data.check_runs.some(check => check.app.id === APP_ID)) {
+
+  if(shouldRun && !foundCheckRun) {
     core.setFailed("central workflow wasn't triggered");
+  }
+
+  if(!shouldRun && foundCheckRun) {
+    core.setFailed("central workflow was triggered (while is shouldn't");
   }
 }

--- a/README.md
+++ b/README.md
@@ -96,9 +96,18 @@ To map commits, checks, and workflow run, and to make sure workflows can rerun w
 Optionally you can define a custom configuration in the `.github` repository by creating a `organization-workflows-settings.yml` file. This configuration should be defined as a YAML file and - for now - has a single configuration setting.
 
 `workflows_repository`: The repository where your organization workflows are defined. (default: `.github`) 
+`include_workflows_repository`: Whether to run these checks for the central workflows_repository. (default: `false`) 
+`exclude.repositories`: Repositories that are excluded and should not trigger organization workflows. Accepts wildcards (default: `[]`)
 
 ```yml
 workflows_repository: our-organization-workflows
+include_workflows_repository: false,
+exclude: 
+  repositories: 
+    - do_not_run_check_for_this_repo
+    - 'playground-*'
+    - test_repository
+    - '*-foobar'
 ```
 ## Action inputs
 The following inputs should be provided for every organization workflow.

--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@ Optionally you can define a custom configuration in the `.github` repository by 
 
 `workflows_repository`: The repository where your organization workflows are defined. (default: `.github`) 
 `include_workflows_repository`: Whether to run these checks for the central workflows_repository. (default: `false`) 
-`exclude.repositories`: Repositories that are excluded and should not trigger organization workflows. Accepts wildcards (default: `[]`)
+`exclude.repositories`: Repositories that are excluded and should not trigger organization workflows. Accepts wildcards. (default: `[]`)
 
 ```yml
 workflows_repository: our-organization-workflows
-include_workflows_repository: false,
+include_workflows_repository: false
 exclude: 
   repositories: 
-    - do_not_run_check_for_this_repo
-    - 'playground-*'
-    - test_repository
-    - '*-foobar'
+  - do_not_run_check_for_this_repo
+  - 'playground-*'
+  - test_repository
+  - '*-foobar'
 ```
 ## Action inputs
 The following inputs should be provided for every organization workflow.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 export const github_host = 'https://github.com'
 export const default_organization_repository = '.github'
 export const app_route = '/org-workflows'
-export const config_keys = ['workflows_repository'] 
+export const config_keys = ['workflows_repository', 'include', 'exclude'] 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 export const github_host = 'https://github.com'
 export const default_organization_repository = '.github'
 export const app_route = '/org-workflows'
-export const config_keys = ['workflows_repository', 'include', 'exclude'] 
+export const config_keys = ['workflows_repository'] 

--- a/src/utils/should-run.ts
+++ b/src/utils/should-run.ts
@@ -1,0 +1,13 @@
+function shouldRun(
+  repositoryName: string, 
+  exclude: string[]
+): boolean {
+  const excludeMatch = exclude.some((repository: string) => {
+    return new RegExp('^' + repository.replace(/\*/g, '.*') + '$').test(repositoryName)
+  });    
+
+  if (excludeMatch) return false;
+  return true;
+}
+
+export default shouldRun;

--- a/test/utils/include-exclude.test.ts
+++ b/test/utils/include-exclude.test.ts
@@ -1,0 +1,72 @@
+import shouldRun from '../../src/utils/should-run';
+
+describe('should run logic', () => {
+  let repositoryName;
+  let exclude;
+  
+  beforeEach(() => {
+    repositoryName = 'foobar';
+  })
+  
+  describe('no exclude pattern is defined', () => {
+    beforeEach(() => {
+      exclude = [];
+    })
+    
+    test('should return true', () => {
+      expect(shouldRun(repositoryName, exclude)).toBe(true)
+    })
+  })
+  
+  describe('exclude pattern is defined', () => {
+    describe('without wildcard', () => {
+      beforeEach(() => {
+        exclude = ['.github', 'exclude-this-repo'];
+      })
+      
+      test('should return true if exclude array doesnt contain repository', () => {
+        repositoryName = 'foobar';
+        expect(shouldRun(repositoryName, exclude)).toBe(true)
+      })
+      
+      test('should return false if exclude array contains repository', () => {
+        repositoryName = '.github';
+        expect(shouldRun(repositoryName, exclude)).toBe(false)
+        
+        repositoryName = 'exclude-this-repo';
+        expect(shouldRun(repositoryName, exclude)).toBe(false)
+      })
+    })
+    
+    describe('with wildcard', () => {
+      beforeEach(() => {
+        exclude = ['exclude-*', '*-ignore', '*-nope-*'];
+      })
+      
+      test('should return true if exclude array doesnt matches repository', () => {
+        repositoryName = 'foo';
+        expect(shouldRun(repositoryName, exclude)).toBe(true)
+        
+        repositoryName = 'foo-exclude-foo';
+        expect(shouldRun(repositoryName, exclude)).toBe(true)
+        
+        repositoryName = 'foo-ignore-foo';
+        expect(shouldRun(repositoryName, exclude)).toBe(true)
+      })
+      
+      test('should return false if exclude array matches repository', () => {
+        repositoryName = 'exclude-';
+        expect(shouldRun(repositoryName, exclude)).toBe(false)
+        
+        repositoryName = 'exclude-foo-yes';
+        expect(shouldRun(repositoryName, exclude)).toBe(false)
+        
+        repositoryName = 'foo-ignore';
+        expect(shouldRun(repositoryName, exclude)).toBe(false)
+        
+        repositoryName = 'foo-nope-foo';
+        expect(shouldRun(repositoryName, exclude)).toBe(false)
+      })
+    })
+  })
+})

--- a/test/utils/include-exclude.test.ts
+++ b/test/utils/include-exclude.test.ts
@@ -1,8 +1,8 @@
 import shouldRun from '../../src/utils/should-run';
 
 describe('should run logic', () => {
-  let repositoryName;
-  let exclude;
+  let repositoryName: string;
+  let exclude: string[];
   
   beforeEach(() => {
     repositoryName = 'foobar';


### PR DESCRIPTION
This PR introduces an `exclude` option for repositories that should be excluded from the organization workflows. Pushes to excluded repositories will not trigger Action runs via this GitHub App. (normal action runs will continue to work)

New config settings:
`include_workflows_repository`: Whether to run these checks for the central workflows_repository. (default: `false`) 
`exclude.repositories`: Repositories that are excluded and should not trigger organization workflows. Accepts wildcards (default: `[]`)

example config: 
```yml
workflows_repository: our-organization-workflows
include_workflows_repository: false,
exclude: 
  repositories: 
  - do_not_run_check_for_this_repo
  - 'playground-*'
  - test_repository
  - '*-foobar'
```
Closes #25