### PR TITLE
Add env var for some configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ The following inputs should be provided for every organization workflow.
 The complete event generated in the repository that triggered the workflow is available at `${{ github.event.client_payload.event.<event_field_path> }}`.
 Checkout [Github's docs](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push) to see the information available in the event.
 
+## Backend Configuration
+
+Environment Variable             | Default               | Description
+---------------------------------|-----------------------|-------------------------------|
+WEBHOOK_SECRET                   | none                  | Github's webhook secret       |
+LOG_LEVEL                        | `debug`               | Log level                     |
+DB_HOST                          | `localhost`           | Database host                 |
+DB_USER                          | none                  | Database user                 |
+DB_PASS                          | none                  | Database password             |
+GITHUB_HOST                      | `https://github.com`  | Github host                   |
+DEFAULT_ORGANIZATION_REPOSITORY  | `.github`             | Default organization repo     |
+APP_ROUTE                        | `/org-workflows`      | Application route             |
+
 ## Development
 ### Codespaces
 A [Codespaces environment](https://github.com/features/codespaces) is defined so you can get started right away. Open this repository in the codespace and run `npm run dev` to start the app in development mode. It will prompt you to follow a couple of instruction to configure your GitHub app and set your .env values.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Checkout [Github's docs](https://docs.github.com/en/developers/webhooks-and-even
 
 ## Backend Configuration
 
+These envrionment variables only apply if you are self-hosting the `organization-workflows` webhook backend.
+
 Environment Variable             | Default               | Description
 ---------------------------------|-----------------------|-------------------------------|
 WEBHOOK_SECRET                   | none                  | Github's webhook secret       |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const github_host = 'https://github.com'
-export const default_organization_repository = '.github'
-export const app_route = '/org-workflows'
-export const config_keys = ['workflows_repository'] 
+export const github_host = process.env.GITHUB_HOST ?? 'https://github.com'
+export const default_organization_repository = process.env.DEFAULT_ORGANIZATION_REPOSITORY ?? '.github'
+export const app_route = process.env.APP_ROUTE ?? '/org-workflows'
+export const config_keys = ['workflows_repository']


### PR DESCRIPTION
# :coffee: Purpose
Allow some constants to be configured as environment variables.

**Included**
* github_host
* default_organization_repository
* app_route

**Not included**
* config_keys: didn't include this configuration because it looks like it is tightly coupled to the code.

# :mag: Use cases
I'd like to change the `default_organization_repository` a non public repo.