### PR TITLE
Fixing branch protection creation and adding missing restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The following inputs should be provided for every organization workflow.
 - **enforce_admin (optional)** Enforce [required status check](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-required-status-checks) for admins. _Default: false_
 - **documentation (optional)**: Link to documentation of this check. This is shown with the status check on the original commit. (eg `.github/workflows/compliance-info.md`) _Default: null_
 
+Note: if your default branch is covered only by a wildcard protection rule and you enable `enforce` or `enforce_admin`, the app will create a new branch protection rule covering only the default branch and copy the existing settings from the wildcard. Keep this in mind when making further changes on branch protection rules
+
 ```yml
     - uses: SvanBoxel/organization-workflow@main
       with:

--- a/src/utils/enforce-protection.ts
+++ b/src/utils/enforce-protection.ts
@@ -25,7 +25,7 @@ async function enforceProtection (
     console.error(e)
   }
 
-  const contexts = protection ? protection.data.required_status_checks.contexts : [];
+  const contexts = protection && protection.data.required_status_checks ? protection.data.required_status_checks.contexts : [];
   const enforce_admins_current_setting = protection && protection.data.enforce_admins.enabled
   const adminForceChange = enforce_admins_current_setting !== enforce_admin
   const contextIndex = contexts.indexOf(context_name)

--- a/src/utils/enforce-protection.ts
+++ b/src/utils/enforce-protection.ts
@@ -25,7 +25,7 @@ async function enforceProtection (
     console.error(e)
   }
 
-  const contexts = protection.data.required_status_checks.contexts;
+  const contexts = protection ? protection.data.required_status_checks.contexts : [];
   const enforce_admins_current_setting = protection && protection.data.enforce_admins.enabled
   const adminForceChange = enforce_admins_current_setting !== enforce_admin
   const contextIndex = contexts.indexOf(context_name)
@@ -57,7 +57,11 @@ async function enforceProtection (
     required_linear_history: protection && protection.data.required_linear_history.enabled,
     allow_force_pushes: protection && protection.data.allow_force_pushes.enabled,
     allow_deletions: protection && protection.data.allow_deletions.enabled,
-    restrictions: null
+    restrictions: protection && protection.data.restrictions ? {
+      apps: protection.data.restrictions.apps.map(({ slug } : { slug: string}) => slug),
+      users: protection.data.restrictions.users.map(({ login } : { login: string}) => login),
+      teams: protection.data.restrictions.teams.map(({ slug } : { slug: string}) => slug),
+    } : null,
   })
 
   return true;


### PR DESCRIPTION
Safely checking if branch protection variable is set, if not, creating an empty array for contexts;

Avoiding overriding restrictions, when already set